### PR TITLE
support limit zero filtering

### DIFF
--- a/src/Be.Vlaanderen.Basisregisters.Api/Search/Pagination/PaginationRequest.cs
+++ b/src/Be.Vlaanderen.Basisregisters.Api/Search/Pagination/PaginationRequest.cs
@@ -8,13 +8,14 @@ namespace Be.Vlaanderen.Basisregisters.Api.Search.Pagination
     public interface IPaginationRequest
     {
         PagedQueryable<T> Paginate<T>(SortedQueryable<T> source);
+        bool HasLimitZero { get; }
     }
 
     public class PaginationRequest : IPaginationRequest
     {
         public int Offset { get; }
-
         public int Limit { get; }
+        public bool HasLimitZero => Limit == 0;
 
         public PaginationRequest(int offset, int limit)
         {
@@ -45,6 +46,7 @@ namespace Be.Vlaanderen.Basisregisters.Api.Search.Pagination
     public class NoPaginationRequest : IPaginationRequest
     {
         public int TotalPages(int totalItemSize) => 1;
+        public bool HasLimitZero => false;
 
         public PagedQueryable<T> Paginate<T>(SortedQueryable<T> source)
         {

--- a/src/Be.Vlaanderen.Basisregisters.Api/Search/Pagination/PaginationRequest.cs
+++ b/src/Be.Vlaanderen.Basisregisters.Api/Search/Pagination/PaginationRequest.cs
@@ -8,14 +8,14 @@ namespace Be.Vlaanderen.Basisregisters.Api.Search.Pagination
     public interface IPaginationRequest
     {
         PagedQueryable<T> Paginate<T>(SortedQueryable<T> source);
-        bool HasLimitZero { get; }
+        bool HasZeroAsLimit { get; }
     }
 
     public class PaginationRequest : IPaginationRequest
     {
         public int Offset { get; }
         public int Limit { get; }
-        public bool HasLimitZero => Limit == 0;
+        public bool HasZeroAsLimit => Limit == 0;
 
         public PaginationRequest(int offset, int limit)
         {
@@ -46,7 +46,7 @@ namespace Be.Vlaanderen.Basisregisters.Api.Search.Pagination
     public class NoPaginationRequest : IPaginationRequest
     {
         public int TotalPages(int totalItemSize) => 1;
-        public bool HasLimitZero => false;
+        public bool HasZeroAsLimit => false;
 
         public PagedQueryable<T> Paginate<T>(SortedQueryable<T> source)
         {

--- a/src/Be.Vlaanderen.Basisregisters.Api/Search/Pagination/PaginationRequest.cs
+++ b/src/Be.Vlaanderen.Basisregisters.Api/Search/Pagination/PaginationRequest.cs
@@ -19,7 +19,7 @@ namespace Be.Vlaanderen.Basisregisters.Api.Search.Pagination
         public PaginationRequest(int offset, int limit)
         {
             Offset = Math.Max(offset, 0);
-            Limit = limit;
+            Limit = Math.Max(limit, 0);
         }
 
         public PagedQueryable<T> Paginate<T>(SortedQueryable<T> source)

--- a/src/Be.Vlaanderen.Basisregisters.Api/Search/Query.cs
+++ b/src/Be.Vlaanderen.Basisregisters.Api/Search/Query.cs
@@ -7,15 +7,14 @@ namespace Be.Vlaanderen.Basisregisters.Api.Search
     using Pagination;
     using Sorting;
 
-    public abstract class Query<T> : Query<T, T, T> where T : class
-    {
-    }
+    public abstract class Query<T> : Query<T, T, T>
+        where T : class
+    { }
 
     public abstract class Query<T, TFilter> : Query<T, TFilter, T>
         where T : class
         where TFilter : class
-    {
-    }
+    { }
 
     public abstract class Query<T, TFilter, TResult>
         where T : class

--- a/src/Be.Vlaanderen.Basisregisters.Api/Search/Query.cs
+++ b/src/Be.Vlaanderen.Basisregisters.Api/Search/Query.cs
@@ -38,7 +38,7 @@ namespace Be.Vlaanderen.Basisregisters.Api.Search
             if (paginationRequest == null)
                 throw new ArgumentNullException(nameof(paginationRequest));
 
-            var items = paginationRequest.HasLimitZero
+            var items = paginationRequest.HasZeroAsLimit
                 ? new List<T>().AsQueryable()
                 : Filter(filtering);
 

--- a/src/Be.Vlaanderen.Basisregisters.Api/Search/Query.cs
+++ b/src/Be.Vlaanderen.Basisregisters.Api/Search/Query.cs
@@ -1,6 +1,7 @@
 namespace Be.Vlaanderen.Basisregisters.Api.Search
 {
     using System;
+    using System.Collections.Generic;
     using System.Linq;
     using System.Linq.Expressions;
     using Filtering;
@@ -37,7 +38,9 @@ namespace Be.Vlaanderen.Basisregisters.Api.Search
             if (paginationRequest == null)
                 throw new ArgumentNullException(nameof(paginationRequest));
 
-            var items = Filter(filtering);
+            var items = paginationRequest.HasLimitZero
+                ? new List<T>().AsQueryable()
+                : Filter(filtering);
 
             return items
                 .WithSorting(sorting, Sorting)

--- a/test/Be.Vlaanderen.Basisregisters.Api.Tests/NoPaginationRequestTests.cs
+++ b/test/Be.Vlaanderen.Basisregisters.Api.Tests/NoPaginationRequestTests.cs
@@ -1,0 +1,56 @@
+namespace Be.Vlaanderen.Basisregisters.Api.Tests
+{
+    using System;
+    using FluentAssertions;
+    using Search.Pagination;
+    using Search.Sorting;
+    using System.Collections.Generic;
+    using System.Linq;
+    using AutoFixture;
+    using Xunit;
+    
+    public class When_creating_a_no_pagination_request
+    {
+        private NoPaginationRequest Sut { get; }
+
+        private readonly SortedQueryable<KeyValuePair<int, Guid>> _queryableItems;
+
+        public When_creating_a_no_pagination_request()
+        {
+            var fixture = new Fixture();
+            Sut = new NoPaginationRequest();
+
+            var items = fixture
+                .CreateMany<Guid>(Math.Abs(fixture.Create<int>()) + 1)
+                .Select((guid, i) => new KeyValuePair<int, Guid>(i, guid));
+
+            _queryableItems = new SortedQueryable<KeyValuePair<int, Guid>>(
+                items.AsQueryable(),
+                new SortingHeader("Key", SortOrder.Ascending));
+        }
+
+        [Fact]
+        public void Then_the_page_starts_at_the_first_item()
+        {
+            Sut.Paginate(_queryableItems).Items
+                .First()
+                .Should().Be(_queryableItems.Items.First());
+        }
+
+        [Fact]
+        public void Then_the_item_page_size_should_be_equal_to_query_size()
+        {
+            Sut.Paginate(_queryableItems).Items
+                .Count()
+                .Should().Be(_queryableItems.Items.Count());
+        }
+
+        [Fact]
+        public void Then_the_pagination_info_total_items_should_be_equal_to_query_count()
+        {
+            Sut.Paginate(_queryableItems)
+                .PaginationInfo.TotalItems
+                .Should().Be(_queryableItems.Items.Count());
+        }
+    }
+}

--- a/test/Be.Vlaanderen.Basisregisters.Api.Tests/NoPaginationRequestTests.cs
+++ b/test/Be.Vlaanderen.Basisregisters.Api.Tests/NoPaginationRequestTests.cs
@@ -52,5 +52,11 @@ namespace Be.Vlaanderen.Basisregisters.Api.Tests
                 .PaginationInfo.TotalItems
                 .Should().Be(_queryableItems.Items.Count());
         }
+
+        [Fact]
+        public void Then_the_pagination_info_has_limit_zero_is_false()
+        {
+            Sut.HasLimitZero.Should().BeFalse();
+        }
     }
 }

--- a/test/Be.Vlaanderen.Basisregisters.Api.Tests/NoPaginationRequestTests.cs
+++ b/test/Be.Vlaanderen.Basisregisters.Api.Tests/NoPaginationRequestTests.cs
@@ -56,7 +56,7 @@ namespace Be.Vlaanderen.Basisregisters.Api.Tests
         [Fact]
         public void Then_the_pagination_info_has_limit_zero_is_false()
         {
-            Sut.HasLimitZero.Should().BeFalse();
+            Sut.HasZeroAsLimit.Should().BeFalse();
         }
     }
 }

--- a/test/Be.Vlaanderen.Basisregisters.Api.Tests/PaginationRequestTests.cs
+++ b/test/Be.Vlaanderen.Basisregisters.Api.Tests/PaginationRequestTests.cs
@@ -106,6 +106,12 @@ namespace Be.Vlaanderen.Basisregisters.Api.Tests
                 .PaginationInfo.TotalItems
                 .Should().Be(QueryableItems.Items.Count());
         }
+
+        [Fact]
+        public void Then_the_pagination_info_has_limit_zero_is_true()
+        {
+            Sut.HasLimitZero.Should().BeTrue();
+        }
     }
 
     public class When_a_pagination_request_has_an_initial_zero_limit : PaginationTestContext
@@ -135,6 +141,12 @@ namespace Be.Vlaanderen.Basisregisters.Api.Tests
             Sut.Paginate(QueryableItems)
                 .PaginationInfo.TotalItems
                 .Should().Be(QueryableItems.Items.Count());
+        }
+
+        [Fact]
+        public void Then_the_pagination_info_has_limit_zero_is_true()
+        {
+            Sut.HasLimitZero.Should().BeTrue();
         }
     }
 
@@ -168,6 +180,12 @@ namespace Be.Vlaanderen.Basisregisters.Api.Tests
             Sut.Paginate(QueryableItems)
                 .PaginationInfo.TotalItems
                 .Should().Be(QueryableItems.Items.Count());
+        }
+
+        [Fact]
+        public void Then_the_pagination_info_has_limit_zero_is_false()
+        {
+            Sut.HasLimitZero.Should().BeFalse();
         }
     }
 

--- a/test/Be.Vlaanderen.Basisregisters.Api.Tests/PaginationRequestTests.cs
+++ b/test/Be.Vlaanderen.Basisregisters.Api.Tests/PaginationRequestTests.cs
@@ -1,79 +1,261 @@
 namespace Be.Vlaanderen.Basisregisters.Api.Tests
 {
+    using System;
     using FluentAssertions;
     using Search.Pagination;
     using Search.Sorting;
     using System.Collections.Generic;
     using System.Linq;
+    using AutoFixture;
     using Xunit;
-
-    public class PaginationRequestTests
+    
+    public class When_a_pagination_request_has_an_initial_negative_offset : PaginationTestContext
     {
-        private static readonly List<TestData> TestDatas = new List<TestData> { new TestData("a"), new TestData("b") };
-
-        [Fact]
-        public void WhenConstructingPaginationRequestWithOffsetLessThan0()
+        protected override PaginationRequest SetUp()
         {
-            var request = new PaginationRequest(-1, 0);
-            request.Offset.Should().Be(0);
+            return new PaginationRequest(CreateNegative(), CreatePositive());
         }
 
         [Fact]
-        public void WhenConstructingPaginationRequestWithOffset0()
+        public void Then_it_actual_offset_is_zero()
         {
-            var request = new PaginationRequest(0, 0);
-            request.Offset.Should().Be(0);
+            Sut.Offset.Should().Be(0);
         }
 
         [Fact]
-        public void WhenConstructingPaginationRequestWithOffsetLargerThan0()
+        public void Then_the_page_starts_at_the_first_item()
         {
-            var expected = 1;
-            var request = new PaginationRequest(expected, 0);
-            request.Offset.Should().Be(expected);
+            Sut.Paginate(QueryableItems).Items
+                .First()
+                .Should().Be(QueryableItems.Items.First());
+        }
+    }
+
+    public class When_a_pagination_request_has_an_initial_offset_zero : PaginationTestContext
+    {
+        protected override PaginationRequest SetUp()
+        {
+            return new PaginationRequest(0, CreatePositive());
         }
 
         [Fact]
-        public void WhenPaginatingWithLimit0()
+        public void Then_it_actual_offset_is_zero()
         {
-            var page = new PaginationRequest(1, 0).Paginate(
-                    new SortedQueryable<TestData>(TestDatas.AsQueryable(),
-                    new SortingHeader("Name", SortOrder.Ascending)));
+            Sut.Offset.Should().Be(0);
+        }
+        
+        [Fact]
+        public void Then_the_page_starts_at_the_first_item()
+        {
+            Sut.Paginate(QueryableItems).Items
+                .First()
+                .Should().Be(QueryableItems.Items.First());
+        }
+    }
 
-            page.Items.Should().BeEmpty();
-            page.PaginationInfo.TotalItems.Should().Be(TestDatas.Count);
+    public class When_a_pagination_request_has_an_initial_positive_offset : PaginationTestContext
+    {
+        private int _expectedOffset;
+
+        protected override PaginationRequest SetUp()
+        {
+            _expectedOffset = CreatePositive();
+            return new PaginationRequest(_expectedOffset, CreatePositive());
         }
 
         [Fact]
-        public void WhenPaginatingWithLimitLessThan0()
+        public void Then_it_actual_offset_the_given_offset()
         {
-            var page = new PaginationRequest(1, -1).Paginate(
-                new SortedQueryable<TestData>(TestDatas.AsQueryable(),
-                    new SortingHeader("Name", SortOrder.Ascending)));
-
-            page.Items.Should().BeEmpty();
-            page.PaginationInfo.TotalItems.Should().Be(TestDatas.Count);
+            Sut.Offset.Should().Be(_expectedOffset);
         }
 
         [Fact]
-        public void WhenPaginatingWithLimitLargerThan0()
+        public void Then_the_page_starts_at_the_offset_position()
         {
-            var page = new PaginationRequest(1, 1).Paginate(
-                new SortedQueryable<TestData>(TestDatas.AsQueryable(),
-                    new SortingHeader("Name", SortOrder.Ascending)));
+            Sut.Paginate(QueryableItems).Items
+                .First()
+                .Should().Be(QueryableItems.Items.ToArray()[Sut.Offset]);
+        }
+    }
 
-            page.Items.Should().BeEquivalentTo(TestDatas.Skip(1).Take(1));
-            page.PaginationInfo.TotalItems.Should().Be(TestDatas.Count);
+    public class When_a_pagination_request_has_an_initial_negative_limit : PaginationTestContext
+    {
+        protected override PaginationRequest SetUp()
+        {
+            return new PaginationRequest(CreatePositive(), CreateNegative());
         }
 
-        private class TestData
+        [Fact]
+        public void Then_it_actual_limit_should_be_zero()
         {
-            public string Name { get; set; }
-
-            public TestData(string name)
-            {
-                Name = name;
-            }
+            Sut.Limit.Should().Be(0);
         }
+        
+        [Fact]
+        public void Then_the_item_page_size_should_be_equal_to_the_limit()
+        {
+            Sut.Paginate(QueryableItems).Items
+                .Count()
+                .Should().Be(0);
+        }
+
+        [Fact]
+        public void Then_the_pagination_info_total_items_should_be_equal_to_query_count()
+        {
+            Sut.Paginate(QueryableItems)
+                .PaginationInfo.TotalItems
+                .Should().Be(QueryableItems.Items.Count());
+        }
+    }
+
+    public class When_a_pagination_request_has_an_initial_zero_limit : PaginationTestContext
+    {
+        protected override PaginationRequest SetUp()
+        {
+            return new PaginationRequest(CreatePositive(), 0);
+        }
+
+        [Fact]
+        public void Then_it_actual_limit_should_be_zero()
+        {
+            Sut.Limit.Should().Be(0);
+        }
+        
+        [Fact]
+        public void Then_the_item_page_size_should_be_equal_to_the_limit()
+        {
+            Sut.Paginate(QueryableItems).Items
+                .Count()
+                .Should().Be(0);
+        }
+
+        [Fact]
+        public void Then_the_pagination_info_total_items_should_be_equal_to_query_count()
+        {
+            Sut.Paginate(QueryableItems)
+                .PaginationInfo.TotalItems
+                .Should().Be(QueryableItems.Items.Count());
+        }
+    }
+
+    public class When_a_pagination_request_has_an_initial_positive_limit : PaginationTestContext
+    {
+        private int _limit;
+
+        protected override PaginationRequest SetUp()
+        {
+            _limit = CreatePositive();
+            return new PaginationRequest(CreatePositive(), _limit);
+        }
+
+        [Fact]
+        public void Then_it_actual_limit_should_be_the_fiven_limit()
+        {
+            Sut.Limit.Should().Be(_limit);
+        }
+        
+        [Fact]
+        public void Then_the_item_page_size_should_be_equal_to_the_limit()
+        {
+            Sut.Paginate(QueryableItems).Items
+                .Count()
+                .Should().Be(_limit);
+        }
+
+        [Fact]
+        public void Then_the_pagination_info_total_items_should_be_equal_to_query_count()
+        {
+            Sut.Paginate(QueryableItems)
+                .PaginationInfo.TotalItems
+                .Should().Be(QueryableItems.Items.Count());
+        }
+    }
+
+    public class When_a_pagination_request_has_an_initial_limit_and_offset_that_ : PaginationTestContext
+    {
+        private int _limit;
+        private int _offset;
+        private SortedQueryable<KeyValuePair<int, Guid>> _queryableItems;
+
+        protected override PaginationRequest SetUp()
+        {
+            _limit = CreatePositive();
+            _offset = CreatePositive();
+
+            var listSize = _offset + _limit - 1;
+            var items = Fixture
+                .CreateMany<Guid>(listSize)
+                .Select((guid, i) => new KeyValuePair<int, Guid>(i, guid));
+
+            _queryableItems = new SortedQueryable<KeyValuePair<int, Guid>>(
+                items.AsQueryable(),
+                new SortingHeader("Key", SortOrder.Ascending));
+
+            return new PaginationRequest(_offset, _limit);
+        }
+
+        [Fact]
+        public void Then_it_actual_offset_the_given_offset()
+        {
+            Sut.Offset.Should().Be(_offset);
+        }
+
+        [Fact]
+        public void Then_it_actual_limit_should_be_the_fiven_limit()
+        {
+            Sut.Limit.Should().Be(_limit);
+        }
+
+        [Fact]
+        public void Then_the_page_starts_at_the_offset_position()
+        {
+            Sut.Paginate(_queryableItems).Items
+                .First()
+                .Should().Be(_queryableItems.Items.ToArray()[Sut.Offset]);
+        }
+
+        [Fact]
+        public void Then_the_item_page_size_should_be_less_then_the_limit()
+        {
+            Sut.Paginate(_queryableItems).Items
+                .Count()
+                .Should().BeLessThan(_limit);
+        }
+
+        [Fact]
+        public void Then_the_pagination_info_total_items_should_be_equal_to_query_count()
+        {
+            Sut.Paginate(_queryableItems)
+                .PaginationInfo.TotalItems
+                .Should().Be(_queryableItems.Items.Count());
+        }
+    }
+
+    public abstract class PaginationTestContext
+    {
+        protected Fixture Fixture { get; }
+        protected PaginationRequest Sut { get; }
+        protected SortedQueryable<KeyValuePair<int, Guid>> QueryableItems { get; }
+
+        protected abstract PaginationRequest SetUp();
+
+        protected PaginationTestContext()
+        {
+            Fixture = new Fixture();
+            // ReSharper disable once VirtualMemberCallInConstructor
+            Sut = SetUp();
+
+            var listSize = Sut.Offset + Sut.Limit + CreatePositive();
+            var items = Fixture
+                .CreateMany<Guid>(listSize)
+                .Select((guid, i) => new KeyValuePair<int, Guid>(i, guid));
+
+            QueryableItems = new SortedQueryable<KeyValuePair<int, Guid>>(
+                items.AsQueryable(),
+                new SortingHeader("Key", SortOrder.Ascending));
+        }
+
+        protected int CreatePositive() => Math.Abs(Fixture.Create<int>()) + 1;
+        protected int CreateNegative() => CreatePositive() * -1;
     }
 }

--- a/test/Be.Vlaanderen.Basisregisters.Api.Tests/PaginationRequestTests.cs
+++ b/test/Be.Vlaanderen.Basisregisters.Api.Tests/PaginationRequestTests.cs
@@ -110,7 +110,7 @@ namespace Be.Vlaanderen.Basisregisters.Api.Tests
         [Fact]
         public void Then_the_pagination_info_has_limit_zero_is_true()
         {
-            Sut.HasLimitZero.Should().BeTrue();
+            Sut.HasZeroAsLimit.Should().BeTrue();
         }
     }
 
@@ -146,7 +146,7 @@ namespace Be.Vlaanderen.Basisregisters.Api.Tests
         [Fact]
         public void Then_the_pagination_info_has_limit_zero_is_true()
         {
-            Sut.HasLimitZero.Should().BeTrue();
+            Sut.HasZeroAsLimit.Should().BeTrue();
         }
     }
 
@@ -185,7 +185,7 @@ namespace Be.Vlaanderen.Basisregisters.Api.Tests
         [Fact]
         public void Then_the_pagination_info_has_limit_zero_is_false()
         {
-            Sut.HasLimitZero.Should().BeFalse();
+            Sut.HasZeroAsLimit.Should().BeFalse();
         }
     }
 

--- a/test/Be.Vlaanderen.Basisregisters.Api.Tests/QueryTests.cs
+++ b/test/Be.Vlaanderen.Basisregisters.Api.Tests/QueryTests.cs
@@ -1,0 +1,138 @@
+namespace Be.Vlaanderen.Basisregisters.Api.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Collections.Immutable;
+    using System.Linq;
+    using System.Linq.Expressions;
+    using AutoFixture;
+    using FluentAssertions;
+    using Search;
+    using Search.Filtering;
+    using Search.Pagination;
+    using Search.Sorting;
+    using Xunit;
+
+    public class When_fetching_query_results
+    {
+        protected internal PagedQueryable<string> FetchResult;
+        protected internal FilteringHeader<TestQuery.FilterItem> FilteringHeader;
+        protected internal SortingHeader SortingHeader;
+        protected internal PaginationRequest PaginationRequest;
+        private readonly IEnumerable<TestQuery.Item> _queryData;
+
+        public When_fetching_query_results()
+        {
+            _queryData = new Fixture()
+                .CreateMany<string>(15)
+                .Select((s, i) => new TestQuery.Item {Index = i, Value = s})
+                .ToImmutableList();
+
+            FilteringHeader = new FilteringHeader<TestQuery.FilterItem>(default);
+            SortingHeader = new SortingHeader("Value", SortOrder.Descending);
+            PaginationRequest = new PaginationRequest(0, _queryData.Count());
+            FetchResult = new TestQuery(_queryData)
+                .Fetch(
+                    FilteringHeader,
+                    SortingHeader,
+                    PaginationRequest);
+        }
+
+        [Fact]
+        public void Then_the_given_sorting_should_be_set()
+        {
+            FetchResult.Sorting.Should().Be(SortingHeader);
+        }
+
+        [Fact]
+        public void Then_the_items_are_the_expected_to_be_the_filtered_sorted_transformed_list()
+        {
+            var expectedItems = _queryData
+                .OrderByDescending(item => item.Value)
+                .Select(TestQuery.TransForm);
+
+            FetchResult.Items.Should().ContainInOrder(expectedItems);
+        }
+    }
+
+
+    public class When_fetching_query_results_without_a_filter
+    {
+        [Fact]
+        public void Then_an_argument_exception_is_thrown()
+        {
+            Action fetch = () => new TestQuery(new List<TestQuery.Item>())
+                .Fetch(
+                    null,
+                    new SortingHeader("Value", SortOrder.Descending),
+                    new PaginationRequest(0, 100));
+
+            fetch.Should().Throw<ArgumentNullException>();
+        }
+    }
+
+    public class When_fetching_query_results_without_sorting
+    {
+        [Fact]
+        public void Then_an_argument_exception_is_thrown()
+        {
+            Action fetch = () => new TestQuery(new List<TestQuery.Item>())
+                .Fetch(
+                    new FilteringHeader<TestQuery.FilterItem>(default),
+                    null,
+                    new PaginationRequest(0, 100));
+
+            fetch.Should().Throw<ArgumentNullException>();
+        }
+    }
+
+    public class When_fetching_query_results_without_pagination
+    {
+        [Fact]
+        public void Then_an_argument_exception_is_thrown()
+        {
+            Action fetch = () => new TestQuery(new List<TestQuery.Item>())
+                .Fetch(
+                    new FilteringHeader<TestQuery.FilterItem>(default),
+                    new SortingHeader("Value", SortOrder.Descending),
+                    null);
+
+            fetch.Should().Throw<ArgumentNullException>();
+        }
+    }
+
+    public class TestQuery : Query<TestQuery.Item, TestQuery.FilterItem, string>
+    {
+        private readonly IEnumerable<Item> _queryData;
+
+        public TestQuery(IEnumerable<Item> queryData)
+        {
+            _queryData = queryData;
+        }
+
+        protected override IQueryable<Item> Filter(FilteringHeader<FilterItem> filtering) => _queryData.AsQueryable();
+
+        protected override ISorting Sorting =>  new TestQuerySorting();
+
+        protected override Expression<Func<Item, string>> Transformation => item => TransForm(item);
+
+        public static string TransForm(Item item) => $"{item.Index}-{item.Value}";
+
+        private class TestQuerySorting : ISorting
+        {
+            public IEnumerable<string> SortableFields => new[] { nameof(Item.Index), nameof(Item.Value) };
+            public SortingHeader DefaultSortingHeader => new SortingHeader(nameof(Item.Index), SortOrder.Ascending);
+        }
+
+        public class Item
+        {
+            public int Index { get; set; }
+            public string Value { get; set; }
+        }
+
+        public class FilterItem
+        {}
+    }
+
+
+}

--- a/test/Be.Vlaanderen.Basisregisters.Api.Tests/QueryTests.cs
+++ b/test/Be.Vlaanderen.Basisregisters.Api.Tests/QueryTests.cs
@@ -54,8 +54,7 @@ namespace Be.Vlaanderen.Basisregisters.Api.Tests
             FetchResult.Items.Should().ContainInOrder(expectedItems);
         }
     }
-
-
+    
     public class When_fetching_query_results_without_a_filter
     {
         [Fact]
@@ -98,6 +97,39 @@ namespace Be.Vlaanderen.Basisregisters.Api.Tests
                     null);
 
             fetch.Should().Throw<ArgumentNullException>();
+        }
+    }
+
+    public class When_fetching_query_results_with_limit_zero_pagination
+    {
+        protected internal PagedQueryable<string> FetchResult;
+
+        public When_fetching_query_results_with_limit_zero_pagination()
+        {
+            const int limitZero = 0;
+
+            var queryData = new Fixture()
+                .CreateMany<string>(15)
+                .Select((s, i) => new TestQuery.Item { Index = i, Value = s })
+                .ToImmutableList();
+
+            FetchResult = new TestQuery(queryData)
+                .Fetch(
+                    new FilteringHeader<TestQuery.FilterItem>(default),
+                    new SortingHeader("Value", SortOrder.Descending),
+                    new PaginationRequest(0, limitZero));
+        }
+
+        [Fact]
+        public void Then_the_items_is_empty()
+        {
+            FetchResult.Items.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void Then_the_total_paginated_items_is_zero()
+        {
+            FetchResult.PaginationInfo.TotalItems.Should().Be(0);
         }
     }
 

--- a/test/Be.Vlaanderen.Basisregisters.Api.Tests/paket.references
+++ b/test/Be.Vlaanderen.Basisregisters.Api.Tests/paket.references
@@ -8,3 +8,4 @@ Microsoft.NET.Test.Sdk
 Microsoft.AspNetCore.TestHost
 FluentAssertions
 Moq
+AutoFixture


### PR DESCRIPTION
GR-734: limit 0 gives 404

Use empty collection instead of quering when page size is 0