### PR TITLE
fix: change Pagination.Items to IAsyncQueryable<T>

### DIFF
--- a/src/Be.Vlaanderen.Basisregisters.Api/Search/IAsyncQueryable.cs
+++ b/src/Be.Vlaanderen.Basisregisters.Api/Search/IAsyncQueryable.cs
@@ -1,0 +1,7 @@
+namespace Be.Vlaanderen.Basisregisters.Api.Search
+{
+    using System.Collections.Generic;
+    using System.Linq;
+
+    public interface IAsyncQueryable<out T> : IQueryable<T>, IAsyncEnumerable<T> { }
+}

--- a/src/Be.Vlaanderen.Basisregisters.Api/Search/Pagination/PagedQueryable.cs
+++ b/src/Be.Vlaanderen.Basisregisters.Api/Search/Pagination/PagedQueryable.cs
@@ -1,17 +1,18 @@
 namespace Be.Vlaanderen.Basisregisters.Api.Search.Pagination
 {
     using System.Linq;
+    using Helpers;
     using Sorting;
 
     public class PagedQueryable<T>
     {
-        public IQueryable<T> Items { get; }
+        public IAsyncQueryable<T> Items { get; }
         public PaginationInfo PaginationInfo { get; }
         public SortingHeader Sorting { get; }
 
         public PagedQueryable(IQueryable<T> items, PaginationInfo paginationInfo, SortingHeader sortingHeader)
         {
-            Items = items;
+            Items = items.AsAsyncQueryable();
             PaginationInfo = paginationInfo;
             Sorting = sortingHeader;
         }


### PR DESCRIPTION
GR-734: Limit 0 gives a 500

Not every impelentation of IQueryable<T> implements IAsyncEnumerable<T>, 
which can throw an error on  calling ToListAsyc

Use an the IAsyncQueryable<T> for Pagination.Items 
to explicity force an IQueryable<T> impelentation that supports IAsyncEnumerable<T>
