### PR TITLE
Fix: remove explicit interace that conflicts with linq extensions

### DIFF
--- a/src/Be.Vlaanderen.Basisregisters.Api/Search/Helpers/AsAsyncQueryableExtension.cs
+++ b/src/Be.Vlaanderen.Basisregisters.Api/Search/Helpers/AsAsyncQueryableExtension.cs
@@ -13,7 +13,16 @@ namespace Be.Vlaanderen.Basisregisters.Api.Search.Helpers
     {
         public static IQueryable<T> AsAsyncQueryable<T>(this IEnumerable<T> source)
         {
-            return new AsyncQueryable<T>(source);
+            return source is IQueryable<T> queryable
+                ? queryable.AsAsyncQueryable()
+                : new AsyncQueryable<T>(source);
+        }
+
+        public static IQueryable<T> AsAsyncQueryable<T>(this IQueryable<T> source)
+        {
+            return source is IAsyncEnumerable<T>
+                ? source
+                : new AsyncQueryable<T>(source);
         }
     }
 

--- a/src/Be.Vlaanderen.Basisregisters.Api/Search/Helpers/AsAsyncQueryableExtension.cs
+++ b/src/Be.Vlaanderen.Basisregisters.Api/Search/Helpers/AsAsyncQueryableExtension.cs
@@ -11,13 +11,13 @@ namespace Be.Vlaanderen.Basisregisters.Api.Search.Helpers
 
     public static class AsAsyncQueryableExtension
     {
-        public static IAsyncQueryable<T> AsAsyncQueryable<T>(this IEnumerable<T> source)
+        public static IQueryable<T> AsAsyncQueryable<T>(this IEnumerable<T> source)
         {
             return new AsyncQueryable<T>(source);
         }
     }
 
-    internal class AsyncQueryable<T> : IAsyncQueryable<T>
+    internal class AsyncQueryable<T> : IQueryable<T>, IAsyncEnumerable<T>
     {
         private readonly IQueryable<T> _queryable;
 

--- a/src/Be.Vlaanderen.Basisregisters.Api/Search/IAsyncQueryable.cs
+++ b/src/Be.Vlaanderen.Basisregisters.Api/Search/IAsyncQueryable.cs
@@ -1,7 +1,0 @@
-namespace Be.Vlaanderen.Basisregisters.Api.Search
-{
-    using System.Collections.Generic;
-    using System.Linq;
-
-    public interface IAsyncQueryable<out T> : IQueryable<T>, IAsyncEnumerable<T> { }
-}

--- a/src/Be.Vlaanderen.Basisregisters.Api/Search/Pagination/PagedQueryable.cs
+++ b/src/Be.Vlaanderen.Basisregisters.Api/Search/Pagination/PagedQueryable.cs
@@ -6,7 +6,7 @@ namespace Be.Vlaanderen.Basisregisters.Api.Search.Pagination
 
     public class PagedQueryable<T>
     {
-        public IAsyncQueryable<T> Items { get; }
+        public IQueryable<T> Items { get; }
         public PaginationInfo PaginationInfo { get; }
         public SortingHeader Sorting { get; }
 

--- a/src/Be.Vlaanderen.Basisregisters.Api/Search/Pagination/PaginationRequest.cs
+++ b/src/Be.Vlaanderen.Basisregisters.Api/Search/Pagination/PaginationRequest.cs
@@ -4,6 +4,7 @@ namespace Be.Vlaanderen.Basisregisters.Api.Search.Pagination
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using Helpers;
 
     public interface IPaginationRequest
     {
@@ -26,20 +27,23 @@ namespace Be.Vlaanderen.Basisregisters.Api.Search.Pagination
         public PagedQueryable<T> Paginate<T>(SortedQueryable<T> source)
         {
             var items = source.Items;
-            var itemsInRequestedPage = new List<T>().AsQueryable();
-
-            if (Limit > 0)
-            {
-                itemsInRequestedPage = items
-                    .Skip(Offset)
-                    .Take(Limit);
-            }
-
             var totalItemSize = items.Count();
-            var totalPages = (int)Math.Ceiling((double)totalItemSize / Limit);
-            var paginationInfo = new PaginationInfo(Offset, Limit, totalItemSize, totalPages);
 
-            return new PagedQueryable<T>(itemsInRequestedPage, paginationInfo, source.Sorting);
+            if (Limit == 0)
+                return new PagedQueryable<T>(
+                    new List<T>().AsQueryable(),
+                    new PaginationInfo(Offset, Limit, totalItemSize, 1),
+                    source.Sorting);
+
+            var itemsInRequestedPage = items
+                .Skip(Offset)
+                .Take(Limit);
+            var totalPages = (int)Math.Ceiling((double)totalItemSize / Limit);
+
+            return new PagedQueryable<T>(
+                itemsInRequestedPage,
+                new PaginationInfo(Offset, Limit, totalItemSize, totalPages),
+                source.Sorting);
         }
     }
 

--- a/test/Be.Vlaanderen.Basisregisters.Api.Tests/PagedQueryableTests.cs
+++ b/test/Be.Vlaanderen.Basisregisters.Api.Tests/PagedQueryableTests.cs
@@ -1,0 +1,39 @@
+namespace Be.Vlaanderen.Basisregisters.Api.Tests
+{
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Linq.Expressions;
+    using FluentAssertions;
+    using Search.Pagination;
+    using Search.Sorting;
+    using Xunit;
+
+    public class When_creating_a_paged_queryable
+    {
+        [Fact]
+        public void Then_the_items_queryable_implements_async_enumerable()
+        {
+            var sorting = new SortingHeader("Value", SortOrder.Ascending);
+            var paginationInfo = new PaginationInfo(0, 0, 0, 1);
+
+            var pagedQueryable = new PagedQueryable<QueryItem>(new QueryAbleWithoutAsync<QueryItem>(), paginationInfo,sorting);
+
+            pagedQueryable.Items.Should().BeAssignableTo<IAsyncEnumerable<QueryItem>>();
+        }
+
+        private class QueryAbleWithoutAsync<T> : IQueryable<T>
+        {
+            public IEnumerator<T> GetEnumerator() => throw new NotImplementedException();
+
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+            public Type ElementType { get; }
+            public Expression Expression { get; }
+            public IQueryProvider Provider { get; }
+        }
+
+        private class QueryItem { }
+    }
+}

--- a/test/Be.Vlaanderen.Basisregisters.Api.Tests/PaginationRequestTests.cs
+++ b/test/Be.Vlaanderen.Basisregisters.Api.Tests/PaginationRequestTests.cs
@@ -108,6 +108,14 @@ namespace Be.Vlaanderen.Basisregisters.Api.Tests
         }
 
         [Fact]
+        public void Then_the_pagination_info_total_pages_should_be_one()
+        {
+            Sut.Paginate(QueryableItems)
+                .PaginationInfo.TotalPages
+                .Should().Be(1);
+        }
+
+        [Fact]
         public void Then_the_pagination_info_has_limit_zero_is_true()
         {
             Sut.HasZeroAsLimit.Should().BeTrue();
@@ -141,6 +149,14 @@ namespace Be.Vlaanderen.Basisregisters.Api.Tests
             Sut.Paginate(QueryableItems)
                 .PaginationInfo.TotalItems
                 .Should().Be(QueryableItems.Items.Count());
+        }
+
+        [Fact]
+        public void Then_the_pagination_info_total_pages_should_be_one()
+        {
+            Sut.Paginate(QueryableItems)
+                .PaginationInfo.TotalPages
+                .Should().Be(1);
         }
 
         [Fact]


### PR DESCRIPTION
GR-734: Limit 0 gives a 500
Removed Explicit interface becuase IQueryable<T> and IAsyncEnumerable<T> conflict for linq extension methods

The PagedQueryable.Items now always contains an IQueryable<T> that implements IAsyncEnumerable<T> but it's inferred, so this get's checked by a unit test.