### PR TITLE
fix: inject startup options in ProblemDetailException mapping GRAR-170

### DIFF
--- a/src/Be.Vlaanderen.Basisregisters.Api/Exceptions/ApiProblemDetailsExceptionMapper.cs
+++ b/src/Be.Vlaanderen.Basisregisters.Api/Exceptions/ApiProblemDetailsExceptionMapper.cs
@@ -1,0 +1,30 @@
+namespace Be.Vlaanderen.Basisregisters.Api.Exceptions
+{
+    using System;
+    using BasicApiProblem;
+
+    internal class ApiProblemDetailsExceptionMapper
+    {
+        private readonly StartupConfigureOptions? _options;
+        private readonly ApiProblemDetailsExceptionMapping _mapping;
+
+        public ApiProblemDetailsExceptionMapper(
+            StartupConfigureOptions? options,
+            ApiProblemDetailsExceptionMapping apiProblemDetailsExceptionMapping)
+        {
+            _options = options;
+            _mapping = apiProblemDetailsExceptionMapping ?? throw new ArgumentNullException(nameof(apiProblemDetailsExceptionMapping));
+        }
+
+        public bool Handles(ApiProblemDetailsException? exception)
+            => exception?.Details != null && _mapping.Handles(exception);
+
+        public ProblemDetails Map(ApiProblemDetailsException exception)
+        {
+            if (!Handles(exception))
+                throw new InvalidCastException("Could not map problem details!");
+
+            return _mapping.Map(_options, exception);
+        }
+    }
+}

--- a/src/Be.Vlaanderen.Basisregisters.Api/Exceptions/ApiProblemDetailsExceptionMapping.cs
+++ b/src/Be.Vlaanderen.Basisregisters.Api/Exceptions/ApiProblemDetailsExceptionMapping.cs
@@ -3,28 +3,9 @@ namespace Be.Vlaanderen.Basisregisters.Api.Exceptions
     using System;
     using BasicApiProblem;
 
-    public class ApiProblemDetailsExceptionMapping
+    public abstract class ApiProblemDetailsExceptionMapping
     {
-        private readonly Func<ApiProblemDetailsException, bool> _handles;
-        private readonly Func<ApiProblemDetailsException, ProblemDetails> _mapProblemDetails;
-
-        public ApiProblemDetailsExceptionMapping(
-            Func<ApiProblemDetailsException, bool>? handles,
-            Func<ApiProblemDetailsException, ProblemDetails>? mapApiProblemDetailException)
-        {
-            _handles = handles ?? (_ => false) ;
-            _mapProblemDetails = mapApiProblemDetailException ?? throw new ArgumentNullException(nameof(mapApiProblemDetailException));
-        }
-
-        public bool Handles(ApiProblemDetailsException? exception)
-            => exception?.Details != null && _handles(exception);
-
-        public ProblemDetails Map(ApiProblemDetailsException exception)
-        {
-            if (!Handles(exception))
-                throw new InvalidCastException("Could not map problem details!");
-
-            return _mapProblemDetails(exception);
-        }
+        public abstract bool Handles(Exception exception);
+        public abstract ProblemDetails Map(StartupConfigureOptions options, ApiProblemDetailsException exception);
     }
 }

--- a/src/Be.Vlaanderen.Basisregisters.Api/Exceptions/ExceptionHandler.cs
+++ b/src/Be.Vlaanderen.Basisregisters.Api/Exceptions/ExceptionHandler.cs
@@ -13,7 +13,7 @@ namespace Be.Vlaanderen.Basisregisters.Api.Exceptions
     public class ExceptionHandler
     {
         private readonly ILogger<ApiExceptionHandler> _logger;
-        private readonly IEnumerable<ApiProblemDetailsExceptionMapping> _apiProblemDetailsExceptionMappings;
+        private readonly IEnumerable<ApiProblemDetailsExceptionMapper> _apiProblemDetailsExceptionMappers;
         private readonly IEnumerable<IExceptionHandler> _exceptionHandlers;
 
         public ExceptionHandler(
@@ -34,7 +34,8 @@ namespace Be.Vlaanderen.Basisregisters.Api.Exceptions
             StartupConfigureOptions? options)
         {
             _logger = logger;
-            _apiProblemDetailsExceptionMappings = apiProblemDetailsExceptionMappings;
+            _apiProblemDetailsExceptionMappers = apiProblemDetailsExceptionMappings
+                .Select(configuration => new ApiProblemDetailsExceptionMapper(options, configuration));
             _exceptionHandlers = customExceptionHandlers
                 .Concat(DefaultExceptionHandlers.GetHandlers(options));
         }
@@ -44,7 +45,7 @@ namespace Be.Vlaanderen.Basisregisters.Api.Exceptions
         {
             if (exception is ApiProblemDetailsException problemDetailsException)
             {
-                var problemDetailMappings = _apiProblemDetailsExceptionMappings
+                var problemDetailMappings = _apiProblemDetailsExceptionMappers
                     .Where(mapping => mapping.Handles(problemDetailsException))
                     .ToList();
 


### PR DESCRIPTION
breaks the just introduced mapping (but is not used yet)