### PR TITLE
fix: remove hardcoded instances of ProblemDetailsHelper GRAR-1814

### DIFF
--- a/src/Be.Vlaanderen.Basisregisters.Api/Exceptions/ApiExceptionHandler.cs
+++ b/src/Be.Vlaanderen.Basisregisters.Api/Exceptions/ApiExceptionHandler.cs
@@ -16,8 +16,6 @@ namespace Be.Vlaanderen.Basisregisters.Api.Exceptions
 
     public static class ApiExceptionHandlerExtension
     {
-        private static ILogger<ApiExceptionHandler> _logger;
-
         public static IApplicationBuilder UseApiExceptionHandler(
             this IApplicationBuilder app,
             ILoggerFactory loggerFactory,
@@ -30,7 +28,7 @@ namespace Be.Vlaanderen.Basisregisters.Api.Exceptions
                     Common = { LoggerFactory = loggerFactory },
                     Api = { CustomExceptionHandlers = new IExceptionHandler[] { } }
                 },
-                null);
+                app.ApplicationServices.GetRequiredService<ProblemDetailsHelper>());
 
         public static IApplicationBuilder UseApiExceptionHandler(
             this IApplicationBuilder app,
@@ -45,29 +43,28 @@ namespace Be.Vlaanderen.Basisregisters.Api.Exceptions
                     Common = { LoggerFactory = loggerFactory },
                     Api = { CustomExceptionHandlers = customExceptionHandlers }
                 },
-                null);
+                app.ApplicationServices.GetRequiredService<ProblemDetailsHelper>());
 
         internal static IApplicationBuilder UseApiExceptionHandler(
             this IApplicationBuilder app,
             string corsPolicyName,
-            StartupUseOptions startupUseOptions,
-            StartupConfigureOptions? startupConfigureOptions)
+            StartupUseOptions startupUseOptions)
             => UseApiExceptionHandling(
                 app,
                 corsPolicyName,
                 startupUseOptions,
-                startupConfigureOptions);
+                app.ApplicationServices.GetRequiredService<ProblemDetailsHelper>());
 
         private static IApplicationBuilder UseApiExceptionHandling(
             IApplicationBuilder app,
             string corsPolicyName,
             StartupUseOptions startupUseOptions,
-            StartupConfigureOptions? startupConfigureOptions)
+            ProblemDetailsHelper problemDetailsHelper)
         {
-            _logger = startupUseOptions.Common.LoggerFactory.CreateLogger<ApiExceptionHandler>();
+            var logger = startupUseOptions.Common.LoggerFactory.CreateLogger<ApiExceptionHandler>();
             var customHandlers = startupUseOptions.Api.CustomExceptionHandlers ?? new IExceptionHandler[]{ };
             var problemDetailMappers = startupUseOptions.Api.ProblemDetailsExceptionMappers ?? new ApiProblemDetailsExceptionMapping[] {};
-            var exceptionHandler = new ExceptionHandler(_logger, problemDetailMappers, customHandlers, startupConfigureOptions);
+            var exceptionHandler = new ExceptionHandler(logger, problemDetailMappers, customHandlers, problemDetailsHelper);
 
             app.UseExceptionHandler(builder =>
             {

--- a/src/Be.Vlaanderen.Basisregisters.Api/Exceptions/BadRequestResponseExamples.cs
+++ b/src/Be.Vlaanderen.Basisregisters.Api/Exceptions/BadRequestResponseExamples.cs
@@ -8,9 +8,15 @@ namespace Be.Vlaanderen.Basisregisters.Api.Exceptions
     public class BadRequestResponseExamples : IExamplesProvider<ValidationProblemDetails>
     {
         private readonly IHttpContextAccessor _httpContextAccessor;
+        private readonly ProblemDetailsHelper _problemDetailsHelper;
 
-        public BadRequestResponseExamples(IHttpContextAccessor httpContextAccessor)
-            => _httpContextAccessor = httpContextAccessor;
+        public BadRequestResponseExamples(
+            IHttpContextAccessor httpContextAccessor,
+            ProblemDetailsHelper problemDetailsHelper)
+        {
+            _httpContextAccessor = httpContextAccessor;
+            _problemDetailsHelper = problemDetailsHelper;
+        }
 
         public ValidationProblemDetails GetExamples() =>
             new ValidationProblemDetails
@@ -20,7 +26,7 @@ namespace Be.Vlaanderen.Basisregisters.Api.Exceptions
                     { "Voornaam", new[] {"Veld is verplicht." }},
                     { "Naam", new[] {"Veld mag niet kleiner zijn dan 4 karakters.", "Veld mag niet groter zijn dan 100 karakters." }}
                 },
-                ProblemInstanceUri = _httpContextAccessor.HttpContext.GetProblemInstanceUri()
+                ProblemInstanceUri = _problemDetailsHelper.GetInstanceUri(_httpContextAccessor.HttpContext)
             };
     }
 }

--- a/src/Be.Vlaanderen.Basisregisters.Api/Exceptions/ExceptionHandler.cs
+++ b/src/Be.Vlaanderen.Basisregisters.Api/Exceptions/ExceptionHandler.cs
@@ -19,27 +19,13 @@ namespace Be.Vlaanderen.Basisregisters.Api.Exceptions
 
         public ExceptionHandler(
             ILogger<ApiExceptionHandler> logger,
-            IEnumerable<IExceptionHandler> customExceptionHandlers)
-            : this(logger, customExceptionHandlers, new StartupConfigureOptions()) { }
-
-        public ExceptionHandler(
-            ILogger<ApiExceptionHandler> logger,
-            IEnumerable<IExceptionHandler> customExceptionHandlers,
-            StartupConfigureOptions? options)
-            : this(logger, new List<ApiProblemDetailsExceptionMapping>(), customExceptionHandlers, options) { }
-
-        public ExceptionHandler(
-            ILogger<ApiExceptionHandler> logger,
             IEnumerable<ApiProblemDetailsExceptionMapping> apiProblemDetailsExceptionMappings,
             IEnumerable<IExceptionHandler> customExceptionHandlers,
-            StartupConfigureOptions? options)
+            ProblemDetailsHelper problemDetailsHelper)
         {
-            if (options == null)
-                throw new ArgumentNullException(nameof(options));
-
             _logger = logger;
             _apiProblemDetailsExceptionMappers = apiProblemDetailsExceptionMappings;
-            _problemDetailsHelper = new ProblemDetailsHelper(options);
+            _problemDetailsHelper = problemDetailsHelper ?? throw new ArgumentNullException(nameof(problemDetailsHelper));
             _exceptionHandlers = customExceptionHandlers.Concat(DefaultExceptionHandlers.GetHandlers(_problemDetailsHelper));
         }
 

--- a/src/Be.Vlaanderen.Basisregisters.Api/Exceptions/InternalServerErrorResponseExamples.cs
+++ b/src/Be.Vlaanderen.Basisregisters.Api/Exceptions/InternalServerErrorResponseExamples.cs
@@ -7,9 +7,15 @@ namespace Be.Vlaanderen.Basisregisters.Api.Exceptions
     public class InternalServerErrorResponseExamples : IExamplesProvider<ProblemDetails>
     {
         private readonly IHttpContextAccessor _httpContextAccessor;
+        private readonly ProblemDetailsHelper _problemDetailsHelper;
 
-        public InternalServerErrorResponseExamples(IHttpContextAccessor httpContextAccessor)
-            => _httpContextAccessor = httpContextAccessor;
+        public InternalServerErrorResponseExamples(
+            IHttpContextAccessor httpContextAccessor,
+            ProblemDetailsHelper problemDetailsHelper)
+        {
+            _httpContextAccessor = httpContextAccessor;
+            _problemDetailsHelper = problemDetailsHelper;
+        }
 
         public ProblemDetails GetExamples() =>
             new ProblemDetails
@@ -18,7 +24,7 @@ namespace Be.Vlaanderen.Basisregisters.Api.Exceptions
                 HttpStatus = StatusCodes.Status500InternalServerError,
                 Title = ProblemDetails.DefaultTitle,
                 Detail = "<meer informatie over de interne fout>",
-                ProblemInstanceUri = _httpContextAccessor.HttpContext.GetProblemInstanceUri()
+                ProblemInstanceUri = _problemDetailsHelper.GetInstanceUri(_httpContextAccessor.HttpContext)
             };
     }
 }

--- a/src/Be.Vlaanderen.Basisregisters.Api/Exceptions/NotAcceptableResponseExamples.cs
+++ b/src/Be.Vlaanderen.Basisregisters.Api/Exceptions/NotAcceptableResponseExamples.cs
@@ -7,9 +7,15 @@ namespace Be.Vlaanderen.Basisregisters.Api.Exceptions
     public class NotAcceptableResponseExamples : IExamplesProvider<ProblemDetails>
     {
         private readonly IHttpContextAccessor _httpContextAccessor;
+        private readonly ProblemDetailsHelper _problemDetailsHelper;
 
-        public NotAcceptableResponseExamples(IHttpContextAccessor httpContextAccessor)
-            => _httpContextAccessor = httpContextAccessor;
+        public NotAcceptableResponseExamples(
+            IHttpContextAccessor httpContextAccessor,
+            ProblemDetailsHelper problemDetailsHelper)
+        {
+            _httpContextAccessor = httpContextAccessor;
+            _problemDetailsHelper = problemDetailsHelper;
+        }
 
         public ProblemDetails GetExamples() =>
             new ProblemDetails
@@ -18,7 +24,7 @@ namespace Be.Vlaanderen.Basisregisters.Api.Exceptions
                 HttpStatus = StatusCodes.Status406NotAcceptable,
                 Title = ProblemDetails.DefaultTitle,
                 Detail = "Het gevraagde formaat is niet beschikbaar.",
-                ProblemInstanceUri = _httpContextAccessor.HttpContext.GetProblemInstanceUri()
+                ProblemInstanceUri = _problemDetailsHelper.GetInstanceUri(_httpContextAccessor.HttpContext)
             };
     }
 }

--- a/src/Be.Vlaanderen.Basisregisters.Api/Exceptions/PreconditionFailedResponseExamples.cs
+++ b/src/Be.Vlaanderen.Basisregisters.Api/Exceptions/PreconditionFailedResponseExamples.cs
@@ -7,9 +7,15 @@ namespace Be.Vlaanderen.Basisregisters.Api.Exceptions
     public class PreconditionFailedResponseExamples : IExamplesProvider<ProblemDetails>
     {
         private readonly IHttpContextAccessor _httpContextAccessor;
+        private readonly ProblemDetailsHelper _problemDetailsHelper;
 
-        public PreconditionFailedResponseExamples(IHttpContextAccessor httpContextAccessor)
-            => _httpContextAccessor = httpContextAccessor;
+        public PreconditionFailedResponseExamples(
+            IHttpContextAccessor httpContextAccessor,
+            ProblemDetailsHelper problemDetailsHelper)
+        {
+            _httpContextAccessor = httpContextAccessor;
+            _problemDetailsHelper = problemDetailsHelper;
+        }
 
         public ProblemDetails GetExamples() =>
             new ProblemDetails
@@ -18,7 +24,7 @@ namespace Be.Vlaanderen.Basisregisters.Api.Exceptions
                 HttpStatus = StatusCodes.Status412PreconditionFailed,
                 Title = ProblemDetails.DefaultTitle,
                 Detail = "De gevraagde minimum positie van de event store is nog niet bereikt.",
-                ProblemInstanceUri = _httpContextAccessor.HttpContext.GetProblemInstanceUri()
+                ProblemInstanceUri = _problemDetailsHelper.GetInstanceUri(_httpContextAccessor.HttpContext)
             };
     }
 }

--- a/src/Be.Vlaanderen.Basisregisters.Api/Exceptions/ProblemDetailsHelper.cs
+++ b/src/Be.Vlaanderen.Basisregisters.Api/Exceptions/ProblemDetailsHelper.cs
@@ -69,13 +69,7 @@ namespace Be.Vlaanderen.Basisregisters.Api.Exceptions
 
     public static class ProblemDetailsContentHelperExtensions 
     {
-        public static string GetProblemInstanceUri(this HttpContext httpContext)
-        {
-            var configurationOptions = httpContext?.RequestServices?.GetService<StartupConfigureOptions>();
-            return new ProblemDetailsHelper(configurationOptions).GetInstanceUri(httpContext);
-        }
-
-        public static void SetTraceId(this ProblemDetails details, HttpContext httpContext)
-            => details.ProblemInstanceUri = httpContext.GetProblemInstanceUri();
+        public static void SetTraceId(this ProblemDetails details, ProblemDetailsHelper problemDetailsHelper, HttpContext httpContext)
+            => details.ProblemInstanceUri = problemDetailsHelper.GetInstanceUri(httpContext);
     }
 }

--- a/src/Be.Vlaanderen.Basisregisters.Api/Exceptions/ProblemDetailsResponseProvider.cs
+++ b/src/Be.Vlaanderen.Basisregisters.Api/Exceptions/ProblemDetailsResponseProvider.cs
@@ -7,6 +7,7 @@ namespace Be.Vlaanderen.Basisregisters.Api.Exceptions
     using Microsoft.AspNetCore.Hosting;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.AspNetCore.Mvc.Versioning;
+    using Microsoft.Extensions.DependencyInjection;
     using Newtonsoft.Json;
     using StatusCodeProblemDetails = BasicApiProblem.StatusCodeProblemDetails;
 
@@ -63,7 +64,11 @@ namespace Be.Vlaanderen.Basisregisters.Api.Exceptions
                 ? _errorCodeTitles[errorCode]
                 : DefaultErrorCodeTitle;
 
-            ProblemInstanceUri = context.Request.HttpContext.GetProblemInstanceUri();
+            var httpContext = context.Request.HttpContext;
+            ProblemInstanceUri = httpContext
+                .RequestServices
+                .GetRequiredService<ProblemDetailsHelper>()
+                .GetInstanceUri(httpContext);
         }
 
         private static string NullIfEmpty(string value) => string.IsNullOrEmpty(value) ? null : value;

--- a/src/Be.Vlaanderen.Basisregisters.Api/Exceptions/ValidationErrorResponseExamples.cs
+++ b/src/Be.Vlaanderen.Basisregisters.Api/Exceptions/ValidationErrorResponseExamples.cs
@@ -10,9 +10,15 @@ namespace Be.Vlaanderen.Basisregisters.Api.Exceptions
     public class ValidationErrorResponseExamples : IExamplesProvider<ValidationProblemDetails>
     {
         private readonly IHttpContextAccessor _httpContextAccessor;
+        private readonly ProblemDetailsHelper _problemDetailsHelper;
 
-        public ValidationErrorResponseExamples(IHttpContextAccessor httpContextAccessor)
-            => _httpContextAccessor = httpContextAccessor;
+        public ValidationErrorResponseExamples(
+            IHttpContextAccessor httpContextAccessor,
+            ProblemDetailsHelper problemDetailsHelper)
+        {
+            _httpContextAccessor = httpContextAccessor;
+            _problemDetailsHelper = problemDetailsHelper;
+        }
 
         public ValidationProblemDetails GetExamples() =>
             new ValidationProblemDetails(new ValidationException(string.Empty, new List<ValidationFailure>
@@ -22,7 +28,7 @@ namespace Be.Vlaanderen.Basisregisters.Api.Exceptions
                 new ValidationFailure("Naam", "Veld mag niet groter zijn dan 100 karakters.")
             }))
             {
-                ProblemInstanceUri = _httpContextAccessor.HttpContext.GetProblemInstanceUri()
+                ProblemInstanceUri = _problemDetailsHelper.GetInstanceUri(_httpContextAccessor.HttpContext)
             };
     }
 }

--- a/src/Be.Vlaanderen.Basisregisters.Api/StartupDefaults-Use.cs
+++ b/src/Be.Vlaanderen.Basisregisters.Api/StartupDefaults-Use.cs
@@ -160,8 +160,6 @@ namespace Be.Vlaanderen.Basisregisters.Api
 
             GlobalStringLocalizer.Instance = new GlobalStringLocalizer(app.ApplicationServices.GetRequiredService<IServiceProvider>());
 
-            var configureOptions = app.ApplicationServices.GetRequiredService<StartupConfigureOptions>();
-
             if (options.Common.HostingEnvironment.IsDevelopment())
                 app
                     .UseDeveloperExceptionPage()
@@ -176,8 +174,7 @@ namespace Be.Vlaanderen.Basisregisters.Api
 
             app.UseApiExceptionHandler(
                 options.Api.DefaultCorsPolicy,
-                options,
-                configureOptions);
+                options);
             options.MiddlewareHooks.AfterApiExceptionHandler?.Invoke(app);
 
             app

--- a/test/Be.Vlaanderen.Basisregisters.Api.Tests/ExceptionHandlerTests.cs
+++ b/test/Be.Vlaanderen.Basisregisters.Api.Tests/ExceptionHandlerTests.cs
@@ -21,7 +21,9 @@ namespace Be.Vlaanderen.Basisregisters.Api.Tests
             _context = new TestHttpContext();
             _exceptionHandler = new ExceptionHandler(
                 Mock.Of<ILogger<ApiExceptionHandler>>(),
-                new IExceptionHandler[0]);
+                new ApiProblemDetailsExceptionMapping[0],
+                new IExceptionHandler[0],
+                new ProblemDetailsHelper(new StartupConfigureOptions()));
         }
 
         [Fact]
@@ -170,11 +172,13 @@ namespace Be.Vlaanderen.Basisregisters.Api.Tests
 
             var exceptionHandler = new ExceptionHandler(
                 Mock.Of<ILogger<ApiExceptionHandler>>(),
+                new ApiProblemDetailsExceptionMapping[0],
                 new[]
                 {
                     customDomainExceptionHandler.Object,
                     extraCustomDomainExceptionHandler.Object
-                });
+                },
+                new ProblemDetailsHelper(new StartupConfigureOptions()));
 
             try
             {


### PR DESCRIPTION
Breaking changes

- `ProblemDetailHelper` must be registered  (no more hardcoded fallback)
- constructors for setup modified to used `ProblemDetailsHelper` instread of `StartupConfigureOptions`
- extension methods with implicit behaviour removed, requires explicitly using an `ProblemDetailsHelper` from the container