### PR TITLE
perf: refactor pagination to gain performance

### DIFF
--- a/src/Be.Vlaanderen.Basisregisters.Api/Search/Pagination/PaginationInfo.cs
+++ b/src/Be.Vlaanderen.Basisregisters.Api/Search/Pagination/PaginationInfo.cs
@@ -2,17 +2,21 @@ namespace Be.Vlaanderen.Basisregisters.Api.Search.Pagination
 {
     public class PaginationInfo
     {
+        private readonly bool _enableNextPage;
         public int Offset { get; }
 
         public int Limit { get; }
 
-        public bool HasNextPage { get; }
-
-        public PaginationInfo(int offset, int limit, bool hasNextPage)
+        public PaginationInfo(int offset, int limit, bool enableNextPage)
         {
+            _enableNextPage = enableNextPage;
             Offset = offset;
             Limit = limit;
-            HasNextPage = hasNextPage;
+        }
+
+        public bool HasNextPage(int itemCountInCollection)
+        {
+            return _enableNextPage && Limit <= itemCountInCollection;
         }
     }
 }

--- a/src/Be.Vlaanderen.Basisregisters.Api/Search/Pagination/PaginationRequest.cs
+++ b/src/Be.Vlaanderen.Basisregisters.Api/Search/Pagination/PaginationRequest.cs
@@ -36,11 +36,11 @@ namespace Be.Vlaanderen.Basisregisters.Api.Search.Pagination
 
             var itemsInRequestedPage = items
                 .Skip(Offset)
-                .Take(Limit + 1);
+                .Take(Limit);
 
             return new PagedQueryable<T>(
-                itemsInRequestedPage.Take(Limit),
-                new PaginationInfo(Offset, Limit, itemsInRequestedPage.Count() > Limit),
+                itemsInRequestedPage,
+                new PaginationInfo(Offset, Limit, true),
                 source.Sorting);
         }
     }

--- a/test/Be.Vlaanderen.Basisregisters.Api.Tests/NoPaginationRequestTests.cs
+++ b/test/Be.Vlaanderen.Basisregisters.Api.Tests/NoPaginationRequestTests.cs
@@ -49,8 +49,10 @@ namespace Be.Vlaanderen.Basisregisters.Api.Tests
         public void Then_the_pagination_info_total_items_should_be_equal_to_query_count()
         {
             Sut.Paginate(_queryableItems)
-                .PaginationInfo.HasNextPage
-                .Should().BeFalse();
+                .PaginationInfo
+                .HasNextPage(_queryableItems.Items.Count())
+                .Should()
+                .BeFalse();
         }
 
         [Fact]

--- a/test/Be.Vlaanderen.Basisregisters.Api.Tests/PaginationRequestTests.cs
+++ b/test/Be.Vlaanderen.Basisregisters.Api.Tests/PaginationRequestTests.cs
@@ -103,7 +103,8 @@ namespace Be.Vlaanderen.Basisregisters.Api.Tests
         public void Then_the_pagination_info_total_items_should_be_equal_to_query_count()
         {
             Sut.Paginate(QueryableItems)
-                .PaginationInfo.HasNextPage
+                .PaginationInfo
+                .HasNextPage(QueryableItems.Items.Count())
                 .Should().BeFalse();
         }
 
@@ -139,7 +140,8 @@ namespace Be.Vlaanderen.Basisregisters.Api.Tests
         public void Then_the_pagination_info_total_items_should_be_equal_to_query_count()
         {
             Sut.Paginate(QueryableItems)
-                .PaginationInfo.HasNextPage
+                .PaginationInfo
+                .HasNextPage(QueryableItems.Items.Count())
                 .Should().BeFalse();
         }
 
@@ -178,7 +180,8 @@ namespace Be.Vlaanderen.Basisregisters.Api.Tests
         public void Then_the_pagination_info_total_items_should_be_equal_to_query_count()
         {
             Sut.Paginate(QueryableItems)
-                .PaginationInfo.HasNextPage
+                .PaginationInfo
+                .HasNextPage(QueryableItems.Items.Count())
                 .Should().BeTrue();
         }
 
@@ -244,8 +247,9 @@ namespace Be.Vlaanderen.Basisregisters.Api.Tests
         public void Then_the_pagination_info_total_items_should_be_equal_to_query_count()
         {
             Sut.Paginate(_queryableItems)
-                .PaginationInfo.HasNextPage
-                .Should().BeFalse();
+                .PaginationInfo
+                .HasNextPage(_queryableItems.Items.Count())
+                .Should().BeTrue(); //When limit reaches the end of the collection EXACTLY then an empty page will be shown if they follow the next urls
         }
     }
 

--- a/test/Be.Vlaanderen.Basisregisters.Api.Tests/QueryTests.cs
+++ b/test/Be.Vlaanderen.Basisregisters.Api.Tests/QueryTests.cs
@@ -130,7 +130,7 @@ namespace Be.Vlaanderen.Basisregisters.Api.Tests
         [Fact]
         public void Then_the_total_paginated_items_is_zero()
         {
-            _fetchResult.PaginationInfo.HasNextPage.Should().BeFalse();
+            _fetchResult.PaginationInfo.HasNextPage(_fetchResult.Items.Count()).Should().BeFalse();
         }
     }
 


### PR DESCRIPTION
BREAKING CHANGE: Removed `HasNextPage` property from PaginationInfo and replaced it by a method. Side effect: when the collection EXACTLY hits the end with limit, then HasNextPage will return true while before it was false.