### PR TITLE
fix: obsolete warnings

### DIFF
--- a/src/Be.Vlaanderen.Basisregisters.Api/Be.Vlaanderen.Basisregisters.Api.csproj
+++ b/src/Be.Vlaanderen.Basisregisters.Api/Be.Vlaanderen.Basisregisters.Api.csproj
@@ -13,6 +13,10 @@
   </PropertyGroup>
 
   <PropertyGroup>
+    <NoWarn>$(NoWarn);CS1591;CS8618</NoWarn>
+  </PropertyGroup>
+
+  <PropertyGroup>
     <Version>1.0.0</Version>
     <PackageId>Be.Vlaanderen.Basisregisters.Api</PackageId>
     <Title>Be.Vlaanderen.Basisregisters.Api</Title>

--- a/src/Be.Vlaanderen.Basisregisters.Api/Exceptions/ApiException.cs
+++ b/src/Be.Vlaanderen.Basisregisters.Api/Exceptions/ApiException.cs
@@ -27,10 +27,5 @@ namespace Be.Vlaanderen.Basisregisters.Api.Exceptions
 
         /// <inheritdoc />
         public ApiException(string message, int statusCode, Exception inner) : base(message, inner) => StatusCode = statusCode;
-
-        /// <inheritdoc />
-        protected ApiException(SerializationInfo info, StreamingContext context)
-            : base(info, context)
-        { }
     }
 }

--- a/src/Be.Vlaanderen.Basisregisters.Api/Exceptions/ApiProblemDetailsException.cs
+++ b/src/Be.Vlaanderen.Basisregisters.Api/Exceptions/ApiProblemDetailsException.cs
@@ -16,10 +16,5 @@ namespace Be.Vlaanderen.Basisregisters.Api.Exceptions
         {
             Details = problemDetails ?? throw new ArgumentNullException(nameof(problemDetails));
         }
-
-        /// <inheritdoc />
-        protected ApiProblemDetailsException(SerializationInfo info, StreamingContext context)
-            : base(info, context)
-        { }
     }
 }

--- a/src/Be.Vlaanderen.Basisregisters.Api/Exceptions/ExceptionHandler.cs
+++ b/src/Be.Vlaanderen.Basisregisters.Api/Exceptions/ExceptionHandler.cs
@@ -101,10 +101,6 @@ namespace Be.Vlaanderen.Basisregisters.Api.Exceptions
         {
             public UnhandledException()
             { }
-
-            private UnhandledException(SerializationInfo info, StreamingContext context)
-                : base(info, context)
-            { }
         }
     }
 }

--- a/src/Be.Vlaanderen.Basisregisters.Api/ProgramDefaults.cs
+++ b/src/Be.Vlaanderen.Basisregisters.Api/ProgramDefaults.cs
@@ -6,7 +6,6 @@ namespace Be.Vlaanderen.Basisregisters.Api
     using System.Net;
     using System.Security.Cryptography.X509Certificates;
     using System.Text;
-    using Amazon;
     using AspNetCore.Mvc.Formatters.Json;
     using Aws.DistributedMutex;
     using Destructurama;
@@ -15,6 +14,7 @@ namespace Be.Vlaanderen.Basisregisters.Api
     using Microsoft.AspNetCore.Server.Kestrel.Core;
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.Hosting;
     using Microsoft.Extensions.Logging;
     using Newtonsoft.Json;
     using Serilog;
@@ -32,7 +32,7 @@ namespace Be.Vlaanderen.Basisregisters.Api
             Key = key;
         }
 
-        public X509Certificate2 ToCertificate() => new X509Certificate2(Name, Key);
+        public X509Certificate2 ToCertificate() => X509Certificate2.CreateFromEncryptedPemFile(Name, Key);
     }
 
     public class ProgramOptions
@@ -75,8 +75,8 @@ namespace Be.Vlaanderen.Basisregisters.Api
 
     public static class ProgramDefaults
     {
-        public static IWebHostBuilder UseDefaultForApi<T>(
-            this IWebHostBuilder hostBuilder,
+        public static IHostBuilder UseDefaultForApi<T>(
+            this IHostBuilder hostBuilder,
             ProgramOptions options) where T : class
         {
             SelfLog.Enable(Console.WriteLine);
@@ -87,76 +87,81 @@ namespace Be.Vlaanderen.Basisregisters.Api
             ConfigureJsonSerializerSettings();
             ConfigureAppDomainExceptions();
 
-            var environment = hostBuilder.GetSetting("environment");
+            hostBuilder.ConfigureWebHost(webHostBuilder =>
+            {
+                var environment = webHostBuilder.GetSetting("environment");
 
-            return hostBuilder
-                .UseKestrel(x =>
-                {
-                    x.AddServerHeader = false;
+                webHostBuilder
+                    .UseKestrel(x =>
+                    {
+                        x.AddServerHeader = false;
 
-                    // Needs to be bigger than traefik timeout, which is 90seconds
-                    // https://github.com/containous/traefik/issues/3237
-                    x.Limits.KeepAliveTimeout = TimeSpan.FromSeconds(120);
+                        // Needs to be bigger than traefik timeout, which is 90seconds
+                        // https://github.com/containous/traefik/issues/3237
+                        x.Limits.KeepAliveTimeout = TimeSpan.FromSeconds(120);
 
-                    if (environment == "Development")
-                        AddDevelopmentPorts(
-                            x,
-                            options.Hosting.HttpPort,
-                            options.Hosting.HttpsPort,
-                            options.Hosting.HttpsCertificate?.Invoke());
-                })
-                .UseSockets()
-                .CaptureStartupErrors(true)
-                .UseContentRoot(Directory.GetCurrentDirectory())
-                .UseWebRoot("wwwroot")
-                .ConfigureAppConfiguration((hostingContext, config) =>
-                {
-                    var env = hostingContext.HostingEnvironment;
+                        if (environment == "Development")
+                            AddDevelopmentPorts(
+                                x,
+                                options.Hosting.HttpPort,
+                                options.Hosting.HttpsPort,
+                                options.Hosting.HttpsCertificate?.Invoke());
+                    })
+                    .UseSockets()
+                    .CaptureStartupErrors(true)
+                    .UseContentRoot(Directory.GetCurrentDirectory())
+                    .UseWebRoot("wwwroot")
+                    .ConfigureAppConfiguration((hostingContext, config) =>
+                    {
+                        var env = hostingContext.HostingEnvironment;
 
-                    config
-                        .SetBasePath(env.ContentRootPath)
-                        .AddJsonFile("appsettings.json", optional: false, reloadOnChange: false)
-                        .AddJsonFile($"appsettings.{env.EnvironmentName.ToLowerInvariant()}.json", optional: true, reloadOnChange: false)
-                        .AddJsonFile($"appsettings.{Environment.MachineName.ToLowerInvariant()}.json", optional: true, reloadOnChange: false)
-                        .AddEnvironmentVariables()
-                        .AddCommandLine(options.Runtime.CommandLineArgs ?? new string[0]);
+                        config
+                            .SetBasePath(env.ContentRootPath)
+                            .AddJsonFile("appsettings.json", optional: false, reloadOnChange: false)
+                            .AddJsonFile($"appsettings.{env.EnvironmentName.ToLowerInvariant()}.json", optional: true, reloadOnChange: false)
+                            .AddJsonFile($"appsettings.{Environment.MachineName.ToLowerInvariant()}.json", optional: true, reloadOnChange: false)
+                            .AddEnvironmentVariables()
+                            .AddCommandLine(options.Runtime.CommandLineArgs ?? new string[0]);
 
-                    options.MiddlewareHooks.ConfigureAppConfiguration?.Invoke(hostingContext, config);
-                })
-                .ConfigureLogging((hostingContext, logging) =>
-                {
-                    var loggerConfiguration = new LoggerConfiguration()
-                        .ReadFrom.Configuration(hostingContext.Configuration);
+                        options.MiddlewareHooks.ConfigureAppConfiguration?.Invoke(hostingContext, config);
+                    })
+                    .ConfigureLogging((hostingContext, logging) =>
+                    {
+                        var loggerConfiguration = new LoggerConfiguration()
+                            .ReadFrom.Configuration(hostingContext.Configuration);
 
-                    if (options.Logging.WriteTextToConsole)
-                        loggerConfiguration = loggerConfiguration.WriteTo.Console();
+                        if (options.Logging.WriteTextToConsole)
+                            loggerConfiguration = loggerConfiguration.WriteTo.Console();
 
-                    if (options.Logging.WriteJsonToConsole)
-                        loggerConfiguration = loggerConfiguration.WriteTo.Console(new RenderedCompactJsonFormatter());
+                        if (options.Logging.WriteJsonToConsole)
+                            loggerConfiguration = loggerConfiguration.WriteTo.Console(new RenderedCompactJsonFormatter());
 
-                    loggerConfiguration = loggerConfiguration
-                        .Enrich.FromLogContext()
-                        .Enrich.WithMachineName()
-                        .Enrich.WithThreadId()
-                        .Enrich.WithEnvironmentUserName()
-                        .Destructure.JsonNetTypes();
+                        loggerConfiguration = loggerConfiguration
+                            .Enrich.FromLogContext()
+                            .Enrich.WithMachineName()
+                            .Enrich.WithThreadId()
+                            .Enrich.WithEnvironmentUserName()
+                            .Destructure.JsonNetTypes();
 
-                    options.MiddlewareHooks.ConfigureSerilog?.Invoke(hostingContext, loggerConfiguration);
+                        options.MiddlewareHooks.ConfigureSerilog?.Invoke(hostingContext, loggerConfiguration);
 
-                    var logger = Log.Logger = loggerConfiguration.CreateLogger();
+                        var logger = Log.Logger = loggerConfiguration.CreateLogger();
 
-                    logging.AddSerilog(logger);
+                        logging.AddSerilog(logger);
 
-                    options.MiddlewareHooks.ConfigureLogging?.Invoke(hostingContext, logging);
-                })
-                .ConfigureServices((hostingContext, services) =>
-                {
-                    services.AddSingleton(options);
-                })
-                .UseStartup<T>();
+                        options.MiddlewareHooks.ConfigureLogging?.Invoke(hostingContext, logging);
+                    })
+                    .ConfigureServices((hostingContext, services) =>
+                    {
+                        services.AddSingleton(options);
+                    })
+                    .UseStartup<T>();
+            });
+
+            return hostBuilder;
         }
 
-        public static void RunWithLock<T>(this IWebHostBuilder webHostBuilder) where T : class
+        public static void RunWithLock<T>(this IHostBuilder webHostBuilder) where T : class
         {
             var webHost = webHostBuilder.Build();
             var services = webHost.Services;
@@ -184,7 +189,7 @@ namespace Be.Vlaanderen.Basisregisters.Api
             // that as a valid config argument. The 2 lines below prevent that.
             if (commandLineArgs != null &&
                 commandLineArgs.Any() &&
-                commandLineArgs[0].EndsWith($"{Path.GetFileNameWithoutExtension(typeof(T).Assembly.CodeBase)}.exe"))
+                commandLineArgs[0].EndsWith($"{Path.GetFileNameWithoutExtension(typeof(T).Assembly.Location)}.exe"))
                 commandLineArgs = commandLineArgs.Skip(1).ToArray();
 
             return commandLineArgs;

--- a/src/Be.Vlaanderen.Basisregisters.Api/Search/Filtering/Values/SyncEmbedValue.cs
+++ b/src/Be.Vlaanderen.Basisregisters.Api/Search/Filtering/Values/SyncEmbedValue.cs
@@ -84,10 +84,6 @@ namespace Be.Vlaanderen.Basisregisters.Api.Search.Filtering
                 : base("Invalid embed option", GetFailures(argumentValue))
             { }
 
-            private InvalidOptionException(SerializationInfo info, StreamingContext context)
-                : base(info, context)
-            { }
-
             private static IEnumerable<ValidationFailure> GetFailures(string argumentValue)
                 => new[]
                 {

--- a/src/Be.Vlaanderen.Basisregisters.Api/StartupDefaults-Configure.cs
+++ b/src/Be.Vlaanderen.Basisregisters.Api/StartupDefaults-Configure.cs
@@ -127,7 +127,6 @@ namespace Be.Vlaanderen.Basisregisters.Api
         public class MiddlewareHookOptions
         {
             public bool EnableFluentValidation { get; set; } = true;
-            public Action<FluentValidationMvcConfiguration>? FluentValidation { get; set; }
             public Action<MvcDataAnnotationsLocalizationOptions> DataAnnotationsLocalization { get; set; }
             public Action<AuthorizationOptions> Authorization { get; set; }
 
@@ -207,7 +206,7 @@ namespace Be.Vlaanderen.Basisregisters.Api
 
             services
                 .AddHttpContextAccessor()
-
+                .AddDatabaseDeveloperPageExceptionFilter()
                 .ConfigureOptions<ProblemDetailsSetup>()
                 .AddProblemDetails(cfg =>
                 {
@@ -251,14 +250,12 @@ namespace Be.Vlaanderen.Basisregisters.Api
             options.MiddlewareHooks.AfterMvcCore?.Invoke(mvcBuilder);
 
             mvcBuilder
-                .SetCompatibilityVersion(CompatibilityVersion.Version_3_0)
                 .AddDataAnnotationsLocalization(options.MiddlewareHooks.DataAnnotationsLocalization);
 
             if(options.MiddlewareHooks.EnableFluentValidation)
             {
-                mvcBuilder.AddFluentValidation(
-                    options.MiddlewareHooks.FluentValidation
-                    ?? (fv => fv.RegisterValidatorsFromAssemblyContaining<T>()));
+                services.AddFluentValidationAutoValidation();
+                services.AddFluentValidationClientsideAdapters();
             }
 
             mvcBuilder

--- a/src/Be.Vlaanderen.Basisregisters.Api/StartupDefaults-Use.cs
+++ b/src/Be.Vlaanderen.Basisregisters.Api/StartupDefaults-Use.cs
@@ -29,7 +29,7 @@ namespace Be.Vlaanderen.Basisregisters.Api
 
         public class CommonOptions
         {
-            public IContainer ApplicationContainer { get; set; }
+            public ILifetimeScope ApplicationContainer { get; set; }
             public IServiceProvider ServiceProvider { get; set; }
             public IWebHostEnvironment HostingEnvironment { get; set; }
             public IHostApplicationLifetime ApplicationLifetime { get; set; }
@@ -168,7 +168,6 @@ namespace Be.Vlaanderen.Basisregisters.Api
             if (options.Common.HostingEnvironment.IsDevelopment())
                 app
                     .UseDeveloperExceptionPage()
-                    .UseDatabaseErrorPage()
                     .UseBrowserLink();
 
             app.UseCors(policyName: options.Api.DefaultCorsPolicy);

--- a/src/Be.Vlaanderen.Basisregisters.Api/StartupHelpers.cs
+++ b/src/Be.Vlaanderen.Basisregisters.Api/StartupHelpers.cs
@@ -19,7 +19,7 @@ namespace Be.Vlaanderen.Basisregisters.Api
         public const string AllowSpecificOrigin = "AllowSpecificOrigin";
 
         public static void RegisterApplicationLifetimeHandling(
-            IContainer applicationContainer,
+            ILifetimeScope lifetimeScope,
             IHostApplicationLifetime appLifetime)
         {
             appLifetime.ApplicationStarted.Register(() => Log.Information("Application started."));
@@ -30,7 +30,7 @@ namespace Be.Vlaanderen.Basisregisters.Api
                 Log.CloseAndFlush();
             });
 
-            appLifetime.ApplicationStopped.Register(applicationContainer.Dispose);
+            appLifetime.ApplicationStopped.Register(lifetimeScope.Dispose);
 
             Console.CancelKeyPress += (sender, eventArgs) =>
             {

--- a/test/Be.Vlaanderen.Basisregisters.Api.Tests/DefaultHttpResponse.cs
+++ b/test/Be.Vlaanderen.Basisregisters.Api.Tests/DefaultHttpResponse.cs
@@ -38,6 +38,9 @@ namespace Microsoft.AspNetCore.Http.Internal
         private IHttpResponseFeature HttpResponseFeature =>
             _features.Fetch(ref _features.Cache.Response, _nullResponseFeature);
 
+        private IHttpResponseBodyFeature HttpResponseBodyFeature =>
+            HttpContext.Features.Get<IHttpResponseBodyFeature>() ?? new StreamResponseBodyFeature(Stream.Null);
+
         private IResponseCookiesFeature ResponseCookiesFeature =>
             _features.Fetch(ref _features.Cache.Cookies, _newResponseCookiesFeature);
 
@@ -57,8 +60,8 @@ namespace Microsoft.AspNetCore.Http.Internal
 
         public override Stream Body
         {
-            get { return HttpResponseFeature.Body; }
-            set { HttpResponseFeature.Body = value; }
+            get { return HttpResponseBodyFeature.Stream; }
+            set { HttpContext.Features.Set<IHttpResponseBodyFeature>(new StreamResponseBodyFeature(value)); }
         }
 
         public override long? ContentLength

--- a/test/Dummy.Api/Infrastructure/Modules/ApiModule.cs
+++ b/test/Dummy.Api/Infrastructure/Modules/ApiModule.cs
@@ -7,19 +7,9 @@ namespace Dummy.Api.Infrastructure.Modules
 
     public class ApiModule : Module
     {
-        private readonly IServiceCollection _services;
-
-        public ApiModule(IServiceCollection services)
-        {
-            _services = services;
-        }
-
         protected override void Load(ContainerBuilder builder)
         {
             builder.RegisterType<ProblemDetailsHelper>();
-
-            builder
-                .Populate(_services);
         }
     }
 }

--- a/test/Dummy.Api/Infrastructure/Modules/LoggingModule.cs
+++ b/test/Dummy.Api/Infrastructure/Modules/LoggingModule.cs
@@ -9,7 +9,7 @@ namespace Dummy.Api.Infrastructure.Modules
     using Serilog;
     using Serilog.Debugging;
 
-    public class LoggingModule : Module
+    public class LoggingModule
     {
         public LoggingModule(
             IConfiguration configuration,

--- a/test/Dummy.Api/Infrastructure/Program.cs
+++ b/test/Dummy.Api/Infrastructure/Program.cs
@@ -1,30 +1,36 @@
 namespace Dummy.Api.Infrastructure
 {
-    using Microsoft.AspNetCore.Hosting;
+    using Autofac;
+    using Autofac.Extensions.DependencyInjection;
     using Be.Vlaanderen.Basisregisters.Api;
+    using Microsoft.Extensions.Hosting;
+    using Modules;
 
     public static class Program
     {
-        public static void Main(string[] args) => CreateWebHostBuilder(args).Build().Run();
+        public static void Main(string[] args) => CreateHostBuilder(args).Build().Run();
 
-        public static IWebHostBuilder CreateWebHostBuilder(string[] args)
-            => new WebHostBuilder()
-                .UseDefaultForApi<Startup>(
-                    new ProgramOptions
+        public static IHostBuilder CreateHostBuilder(string[] args)
+            => new HostBuilder()
+                .UseServiceProviderFactory(new AutofacServiceProviderFactory(cb =>
+                {
+                    cb.RegisterModule(new ApiModule());
+                }))
+                .UseDefaultForApi<Startup>(new ProgramOptions
+                {
+                    Hosting =
                     {
-                        Hosting =
-                        {
-                            HttpPort = 8000
-                        },
-                        Logging =
-                        {
-                            WriteTextToConsole = false,
-                            WriteJsonToConsole = true
-                        },
-                        Runtime =
-                        {
-                            CommandLineArgs = args
-                        }
-                    });
+                        HttpPort = 8000
+                    },
+                    Logging =
+                    {
+                        WriteTextToConsole = false,
+                        WriteJsonToConsole = true
+                    },
+                    Runtime =
+                    {
+                        CommandLineArgs = args
+                    }
+                });
     }
 }

--- a/test/Dummy.Api/Infrastructure/Startup.cs
+++ b/test/Dummy.Api/Infrastructure/Startup.cs
@@ -5,10 +5,10 @@ namespace Dummy.Api.Infrastructure
     using System.Linq;
     using System.Reflection;
     using Asp.Versioning.ApiExplorer;
-    using Autofac;
     using Autofac.Extensions.DependencyInjection;
     using Be.Vlaanderen.Basisregisters.Api;
     using Configuration;
+    using FluentValidation;
     using Microsoft.AspNetCore.Builder;
     using Microsoft.AspNetCore.Hosting;
     using Microsoft.Extensions.Configuration;
@@ -16,7 +16,6 @@ namespace Dummy.Api.Infrastructure
     using Microsoft.Extensions.Hosting;
     using Microsoft.Extensions.Logging;
     using Microsoft.OpenApi;
-    using Modules;
 
     /// <summary>Represents the startup process for the application.</summary>
     public class Startup
@@ -24,15 +23,13 @@ namespace Dummy.Api.Infrastructure
         private const string DefaultCulture = "en-GB";
         private const string SupportedCultures = "en-GB;en-US;en;nl-BE;nl;fr-BE;fr";
 
-        private IContainer _applicationContainer;
-
         private readonly IConfiguration _configuration;
 
         public Startup(IConfiguration configuration) => _configuration = configuration;
 
         /// <summary>Configures services for the application.</summary>
         /// <param name="services">The collection of services to configure the application with.</param>
-        public IServiceProvider ConfigureServices(IServiceCollection services)
+        public void ConfigureServices(IServiceCollection services)
         {
             services
                 .ConfigureDefaultForApi<Startup>(new StartupConfigureOptions
@@ -79,16 +76,9 @@ namespace Dummy.Api.Infrastructure
                             .ToArray()
                     },
                     MiddlewareHooks =
-                    {
-                        FluentValidation = fv => fv.RegisterValidatorsFromAssemblyContaining<Startup>()
-                    }
-                });
-
-            var containerBuilder = new ContainerBuilder();
-            containerBuilder.RegisterModule(new ApiModule(services));
-            _applicationContainer = containerBuilder.Build();
-
-            return new AutofacServiceProvider(_applicationContainer);
+                    { }
+                })
+                .AddValidatorsFromAssemblyContaining<Startup>();
         }
 
         public void Configure(
@@ -106,7 +96,7 @@ namespace Dummy.Api.Infrastructure
                 {
                     Common =
                     {
-                        ApplicationContainer = _applicationContainer,
+                        ApplicationContainer = serviceProvider.GetAutofacRoot(),
                         ServiceProvider = serviceProvider,
                         HostingEnvironment = env,
                         ApplicationLifetime = appLifetime,


### PR DESCRIPTION
BREAKING CHANGE: this will remove FluentValidation mvc middleware hook Use `services.AddValidatorsFromAssemblyContaining<SomeValidator>();`

BREAKING CHANGE: use ILifetimeScope instead of IContainer